### PR TITLE
Blink controls and aframe upgrade

### DIFF
--- a/examples/basic/index.html
+++ b/examples/basic/index.html
@@ -4,9 +4,9 @@
     <meta charset="utf-8">
     <title>A-Frame Cursor Teleport Component - Basic</title>
     <meta name="description" content="Basic example for Cursor Teleport component."></meta>
-    <script src="https://aframe.io/releases/1.2.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.4.1/aframe.min.js"></script>
     <script src="../../dist/aframe-cursor-teleport-component.min.js"></script>
-    <script src="https://rawgit.com/fernandojsg/aframe-teleport-controls/master/dist/aframe-teleport-controls.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/aframe-blink-controls/dist/aframe-blink-controls.min.js"></script>
   </head>
   <body>
     <script>
@@ -30,22 +30,20 @@
           laser-controls="hand: left"
           raycaster="objects: .clickable; far: 100"
           line="color: red; opacity: 0.75"
-          teleport-controls="
+          blink-controls="
             collisionEntities: .collision;
             cameraRig: #cameraRig;
             teleportOrigin: #head;
-            button: thumbstick;
-            curveShootingSpeed: 8"></a-entity>
+            curveShootingSpeed: 6"></a-entity>
         <a-entity
           laser-controls="hand: right"
           raycaster="objects: .clickable"
           line="color: red; opacity: 0.75"
-          teleport-controls="
+          blink-controls="
             collisionEntities: .collision;
             cameraRig: #cameraRig;
             teleportOrigin: #head;
-            button: thumbstick;
-            curveShootingSpeed: 8"></a-entity>
+            curveShootingSpeed: 6"></a-entity>
       </a-entity>
 
       <!-- scene geometry -->

--- a/examples/custom/index.html
+++ b/examples/custom/index.html
@@ -30,14 +30,14 @@
       </a-assets>
 
       <!-- player -->
-      <a-entity id="cameraRig" position="0 0 0" cursor-teleport="cameraRig: #cameraRig; cameraHead: #head; collisionEntities: .collision; ignoreEntities: .clickable">
+      <a-entity id="cameraRig" position="0 0 0" cursor-teleport="cameraRig: #cameraRig; cameraHead: #head; collisionEntities: #vr-collider; ignoreEntities: .clickable">
         <a-entity id="head" position="0 1.52 0" camera look-controls="reverseMouseDrag: true"></a-entity>
         <a-entity
           laser-controls="hand: left"
           raycaster="objects: .clickable; far: 100"
           line="color: red; opacity: 0.75"
           blink-controls="
-            collisionEntities: .collision;
+            collisionEntities: #vr-collider;
             cameraRig: #cameraRig;
             teleportOrigin: #head;
             curveShootingSpeed: 6"></a-entity>
@@ -46,7 +46,7 @@
           raycaster="objects: .clickable"
           line="color: red; opacity: 0.75"
           blink-controls="
-            collisionEntities: .collision;
+            collisionEntities: #vr-collider;
             cameraRig: #cameraRig;
             teleportOrigin: #head;
             curveShootingSpeed: 6"></a-entity>

--- a/examples/custom/index.html
+++ b/examples/custom/index.html
@@ -4,10 +4,10 @@
     <meta charset="utf-8">
     <title>A-Frame Cursor Teleport Component - Custom</title>
     <meta name="description" content="Basic example for Cursor Teleport component."></meta>
-    <!-- <script src="https://aframe.io/releases/1.0.3/aframe.min.js"></script> -->
-    <script src="https://aframe.io/releases/1.2.0/aframe.min.js"></script>
+
+    <script src="https://aframe.io/releases/1.4.1/aframe.min.js"></script>
     <script src="../../dist/aframe-cursor-teleport-component.min.js"></script>
-    <script src="https://rawgit.com/fernandojsg/aframe-teleport-controls/master/dist/aframe-teleport-controls.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/aframe-blink-controls/dist/aframe-blink-controls.min.js"></script>
 
   </head>
   <body>
@@ -36,22 +36,20 @@
           laser-controls="hand: left"
           raycaster="objects: .clickable; far: 100"
           line="color: red; opacity: 0.75"
-          teleport-controls="
-            collisionEntities: #vr-collider;
+          blink-controls="
+            collisionEntities: .collision;
             cameraRig: #cameraRig;
             teleportOrigin: #head;
-            button: thumbstick;
-            curveShootingSpeed: 8"></a-entity>
+            curveShootingSpeed: 6"></a-entity>
         <a-entity
           laser-controls="hand: right"
           raycaster="objects: .clickable"
           line="color: red; opacity: 0.75"
-          teleport-controls="
-            collisionEntities: #vr-collider;
+          blink-controls="
+            collisionEntities: .collision;
             cameraRig: #cameraRig;
             teleportOrigin: #head;
-            button: thumbstick;
-            curveShootingSpeed: 8"></a-entity>
+            curveShootingSpeed: 6"></a-entity>
       </a-entity>
 
       <!-- scene model -->


### PR DESCRIPTION
* the 2 demos work with both cursor teleport in desktop mode and blink controls in VR mode
* when entering VR mode, there is still a white circle remaining from the cursor teleport, I did not try disabling this
* in the quest headset browser, when NOT in VR mode, cursor teleport circle is visible and responds to raycast position changes, but does not activate upon pressing trigger. I think that's ok but could be debugged in the future. I could create a ticket for it.
* there were some `npm install` problems from old packages, but I did not commit these changes. I can if helpful or we could 'rebase' this component from a newer a-frame webpack boilerplate repo