### PR TITLE
Fix visibility of cursor on iPad and VR

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,9 @@ AFRAME.registerComponent('cursor-teleport', {
 
   init() {
     // platform detect
-    this.mobile = AFRAME.utils.device.isMobile();
+    this.mobile =
+      AFRAME.utils.device.isMobile() ||
+      AFRAME.utils.device.isMobileDeviceRequestingDesktopSite();
 
     // main app
     const sceneEl = this.el.sceneEl;
@@ -52,6 +54,7 @@ AFRAME.registerComponent('cursor-teleport', {
     const mat = new THREE.MeshBasicMaterial();
     const indicatorRing = new THREE.Mesh(geo, mat);
     this.teleportIndicator = indicatorRing;
+    this.teleportIndicator.visible = false;
 
     sceneEl.object3D.add(this.teleportIndicator);
 
@@ -71,6 +74,7 @@ AFRAME.registerComponent('cursor-teleport', {
     this.mouseDown = this.mouseDown.bind(this);
     this.mouseUp = this.mouseUp.bind(this);
     this.easeInOutQuad = this.easeInOutQuad.bind(this);
+    this.hideCursor = this.hideCursor.bind(this);
 
     this.updateRaycastObjects();
   },
@@ -98,9 +102,12 @@ AFRAME.registerComponent('cursor-teleport', {
     canvas.addEventListener('touchstart', this.mouseDown, false);
     canvas.addEventListener('touchmove', this.mouseMove, false);
     canvas.addEventListener('touchend', this.mouseUp, false);
+    window.addEventListener('keydown', this.hideCursor, false);
   },
 
   pause() {
+    this.transitioning = false;
+    this.hideCursor();
     const canvas = this.canvas;
     canvas.removeEventListener('mousedown', this.mouseDown);
     canvas.removeEventListener('mousemove', this.mouseMove);
@@ -108,6 +115,7 @@ AFRAME.registerComponent('cursor-teleport', {
     canvas.removeEventListener('touchstart', this.mouseDown);
     canvas.removeEventListener('touchmove', this.mouseMove);
     canvas.removeEventListener('touchend', this.mouseUp);
+    window.removeEventListener('keydown', this.hideCursor);
   },
 
   updateRaycastObjects() {
@@ -222,6 +230,10 @@ AFRAME.registerComponent('cursor-teleport', {
     this.transitioning = true;
   },
 
+  hideCursor() {
+    this.teleportIndicator.visible = false;
+  },
+
   mouseMove(e) {
     const mouseState = this.getMouseState(e);
     this.mouseX = mouseState.x;
@@ -243,6 +255,7 @@ AFRAME.registerComponent('cursor-teleport', {
     if (this.mouseX === this.mouseXOrig && this.mouseY === this.mouseYOrig) {
       const pos = this.getTeleportPosition(this.mouseX, this.mouseY);
       if (pos) {
+        this.teleportIndicator.visible = true;
         this.teleportIndicator.position.copy(pos);
         this.transition(pos);
       }


### PR DESCRIPTION
- Don't show moving cursor on iPad, only on click.
- Don't show the cursor at all in VR. (fix #51)
- Hide cursor when pressing a key (using wasd controls)