### PR TITLE
Fix isValidNormalsAngle to take into account plane rotation

### DIFF
--- a/examples/basic/index.html
+++ b/examples/basic/index.html
@@ -47,7 +47,7 @@
       </a-entity>
 
       <!-- scene geometry -->
-      <a-entity class="collision" position="0 -.05 0" geometry="primitive: box; width: 8; height: .1; depth: 8" material="color: #ffcc80"></a-entity>
+      <a-entity class="collision" position="0 0 0" rotation="-90 0 0" geometry="primitive: plane; width: 8; height: 8" material="color: #ffcc80"></a-entity>
       <a-entity class="collision" position="2 .75 2" geometry="primitive: box; width: 2; height: .1; depth: 2" material="color: #ff1744"></a-entity>
       <a-entity class="collision" position="2 1.5 -2" geometry="primitive: box; width: 2; height: .1; depth: 2" material="color: #80cbc4"></a-entity>
       <a-entity class="collision" position="-2 2.25 -2" geometry="primitive: box; width: 2; height: .1; depth: 2" material="color: #9ccc65"></a-entity>

--- a/index.js
+++ b/index.js
@@ -41,6 +41,8 @@ AFRAME.registerComponent('cursor-teleport', {
 
     // collision
     this.rayCaster = new THREE.Raycaster();
+    this.collisionObjectNormalMatrix = new THREE.Matrix3();
+    this.collisionWorldNormal = new THREE.Vector3();
     this.referenceNormal = new THREE.Vector3();
     this.rayCastObjects = [];
 
@@ -200,7 +202,7 @@ AFRAME.registerComponent('cursor-teleport', {
           );
           if (
             intersects.length !== 0 &&
-            this.isValidNormalsAngle(intersects[0].face.normal)
+            this.isValidNormalsAngle(intersects[0].face.normal, intersects[0].object)
           ) {
             if (intersects[0].object.userData.collision === true) {
               return intersects[0].point;
@@ -218,8 +220,10 @@ AFRAME.registerComponent('cursor-teleport', {
     };
   })(),
 
-  isValidNormalsAngle(collisionNormal) {
-    const angleNormals = this.referenceNormal.angleTo(collisionNormal);
+  isValidNormalsAngle(collisionNormal, collisionObject) {
+    this.collisionObjectNormalMatrix.getNormalMatrix(collisionObject.matrixWorld);
+    this.collisionWorldNormal.copy(collisionNormal).applyNormalMatrix(this.collisionObjectNormalMatrix);
+    const angleNormals = this.referenceNormal.angleTo(this.collisionWorldNormal);
     return THREE.MathUtils.RAD2DEG * angleNormals <= this.data.landingMaxAngle;
   },
 


### PR DESCRIPTION
Fix isValidNormalsAngle to take into account plane rotation.
I modified the basic example to use a plane instead of box for the ground.
FYI blink-controls uses the same calculation, and simple-navmesh-constraint works correctly with rotated plane as well.