### PR TITLE
Add support to change the size of the default plane

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ For [A-Frame](https://aframe.io).
 | cameraRig | Selector of the camera rig to teleport | |
 | cameraHead | Selector of the scene's active camera ||
 | collisionEntities | Selector of the meshes used to check the collisions. If no value provided a plane at Y=0 is used. | |
+| defaultPlaneSize | Size of the default plane created for collision when `collisionEntities` is not specified | 100 |
 | ignoreEntities | Selector of meshes that may obstruct the teleport raycaster, like UI or other clickable elements.
 | landingNormal | Normal vector to detect collisions with the `collisionEntities` | (0, 1, 0) |
 | landingMaxAngle | Angle threshold (in degrees) used together with `landingNormal` to detect if the mesh is so steep to jump to it. | 45

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ AFRAME.registerComponent('cursor-teleport', {
     cameraHead: { type: 'selector', default: '' },
     cameraRig: { type: 'selector', default: '' },
     collisionEntities: { type: 'string', default: '' },
+    defaultPlaneSize: { type: 'number', default: 100 },
     ignoreEntities: { type: 'string', default: '' },
     landingMaxAngle: { default: 45, min: 0, max: 360 },
     landingNormal: { type: 'vec3', default: { x: 0, y: 1, z: 0 } },
@@ -147,7 +148,7 @@ AFRAME.registerComponent('cursor-teleport', {
     } else {
       if (!this.collisionMesh) {
         // if no collision entities are specified, create a default ground plane collision.
-        const geo = new THREE.PlaneGeometry(50, 50, 1);
+        const geo = new THREE.PlaneGeometry(this.data.defaultPlaneSize, this.data.defaultPlaneSize, 1);
         geo.rotateX(-Math.PI / 2);
         const mat = new THREE.MeshNormalMaterial();
         const collisionMesh = new THREE.Mesh(geo, mat);


### PR DESCRIPTION
Add support to change the size of the default plane created for collision when collisionEntities is not specified, change default from 50 to 100 (closes #58)